### PR TITLE
Clarifies site and laterality qualifiers

### DIFF
--- a/input/fsh/terminology/siteLaterality.fsh
+++ b/input/fsh/terminology/siteLaterality.fsh
@@ -6,7 +6,7 @@ Description:   "Body Structure site laterality qualifier. It indicates - for exa
 * insert SetFmmandStatusRule ( 2, draft)
 * $sct#7771000	"Left (qualifier value)"
 * $sct#24028007 "Right (qualifier value)"
-* $sct#51440002 "Right and left = bilateral (qualifier value)"  // Not sure how bilateral in context of lab order/report could be used
+* $sct#51440002 "Right and left (qualifier value)" // = bilateral, not sure how bilateral in context of lab order/report could be used
 //* $sct#261183002 "Upper (qualifier value)"
 //* $sct#261122009 "Lower (qualifier value)"
 //* $sct#255561001 "Medial (qualifier value)"

--- a/input/fsh/terminology/siteQualifier.fsh
+++ b/input/fsh/terminology/siteQualifier.fsh
@@ -1,29 +1,30 @@
 ValueSet:      SiteQualifierEuVs
-Id:	       siteQualifier-eu
+Id:	           siteQualifier-eu
 Title:	       "Body Structure Qualifier"
 Description:   "Body Structure site qualifier. It indicates - for example - the body site qualifier from which a laboratory specimen is collected. (based on SNOMED CT)"
 // * ^experimental = false
 // * ^publisher = "HL7 Europe"
 // * ^copyright = "HL7 Europe"
 * insert SNOMEDCopyrightForVS
-* insert SetFmmandStatusRule ( 2, draft)
+* insert SetFmmandStatusRule (2, draft)
 //* include codes from valueset $BodystructureLocationQualifierR5
 //* exclude codes from valueset LabLateralityEuVs
-* $sct#7771000 "Left"
-* $sct#24028007 "Right"
-* $sct#51440002 "Bilateral"
-* $sct#46053002 "Distal"
-* $sct#255554000 "Dorsal"
+// following codes are associated with aterality, so not mentioned here, see https://jira.hl7.org/browse/FHIR-51391
+// * $sct#7771000 "Left (qualifier value)"
+// * $sct#24028007 "Right (qualifier value)"
+// * $sct#51440002 "Right and left (qualifier value)"
+* $sct#46053002 "Distal (qualifier value)"
+* $sct#255554000 "Dorsal (qualifier value)"
 //* $sct#264147007 "Plantar" inactive concept
-* $sct#261183002 "Upper"
-* $sct#261122009 "Lower"
-* $sct#255561001 "Medial"
-* $sct#49370004 "Lateral"
-* $sct#264217000 "Superior"
-* $sct#261089000 "Inferior"
-* $sct#255551008 "Posterior"
-* $sct#351726001 "Below"
-* $sct#352730000 "Above"
+* $sct#261183002 "Upper (qualifier value)"
+* $sct#261122009 "Lower (qualifier value)"
+* $sct#255561001 "Medial (qualifier value)"
+* $sct#49370004 "Lateral (qualifier value)"
+* $sct#264217000 "Superior (qualifier value)"
+* $sct#261089000 "Inferior (qualifier value)"
+* $sct#255551008 "Posterior (qualifier value)"
+* $sct#351726001 "Below (qualifier value)"
+* $sct#352730000 "Supra- (qualifier value)"
 * $sct#40415009 "Proximal (qualifier value)"
 * $sct#255549009 "Anterior (qualifier value)"
 * $sct#26283006 "Superficial (qualifier value)"


### PR DESCRIPTION
Addresses inconsistencies in site and laterality qualifier display names.

- Standardizes display names for site qualifiers, ensuring clarity and consistency.
- Refines the `siteLaterality` value set to align with the intended use of laterality concepts.

Relates to FHIR-51375, FHIR-51391