### PR TITLE
Fix invariant expression for Observation.value and extension:value-r5

### DIFF
--- a/input/fsh/profiles/core/medical-test-result-eu-core.fsh
+++ b/input/fsh/profiles/core/medical-test-result-eu-core.fsh
@@ -110,7 +110,8 @@ Description: """This profile introduces essential constraints and extensions for
     * ^requirements = "EHDSObservation.component.referenceRange"
   * interpretation
     * ^requirements = "EHDSObservation.component.interpretation"
+    
 Invariant: obs-value-1
 Description: "The elements Observation.extension:value-r5 and Observation.value[x] SHALL not be used simultaneously."
 Severity: #error
-Expression: "value.empty() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.value[x]').empty()"
+Expression: "value.empty() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.value').empty()"


### PR DESCRIPTION
This pull request makes a small but important correction to the `obs-value-1` invariant in the `medical-test-result-eu-core.fsh` profile. The change updates the FHIR extension URL in the invariant's expression to ensure it references the correct extension.

- Fixed the invariant expression for `obs-value-1` to use the correct extension URL (`extension-Observation.value`) instead of the incorrect (`extension-Observation.value[x]`), ensuring proper validation of mutually exclusive use of `Observation.value[x]` and the extension.